### PR TITLE
✨ Add app list view options, sorting, and French localization

### DIFF
--- a/assets/languages.json
+++ b/assets/languages.json
@@ -1,5 +1,6 @@
 [
   {"name": "English", "file_name": "en.xml"},
+  {"name": "Français", "file_name": "fr.xml"},
   {"name": "Español", "file_name": "es.xml"},
   {"name": "Português (Brasil)", "file_name": "pt.xml"},
   {"name": "日本語", "file_name": "ja.xml"},

--- a/assets/languages/en.xml
+++ b/assets/languages/en.xml
@@ -102,6 +102,14 @@
   <translation key="actions_suffix">actions.</translation>
   <translation key="icon_exported_to">Icon exported to</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Sort</translation>
+  <translation key="sort_name_asc">Name (A→Z)</translation>
+  <translation key="sort_name_desc">Name (Z→A)</translation>
+  <translation key="sort_package">Package</translation>
+  <translation key="sort_state">State</translation>
+  <translation key="sort_type">Type</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">No matches</translation>
   <translation key="view_mode">View</translation>
@@ -159,6 +167,8 @@
   <translation key="never_uninstall">Never uninstall, only deactivate</translation>
   <translation key="export_all_apps">Export all apps list</translation>
   <translation key="refresh_icons">Refresh all icons</translation>
+  <translation key="always_show_icons">Always show icons</translation>
+  <translation key="always_show_icons_tooltip">Show app icons by default in both list and mosaic views</translation>
   <translation key="language">Language</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/en.xml
+++ b/assets/languages/en.xml
@@ -42,7 +42,8 @@
   <translation key="log_tooltip">View last log</translation>
   <translation key="browse_tooltip">Import community data</translation>
   <translation key="settings_tooltip">Settings</translation>
-  <translation key="icon_view_tooltip">Toggle icon view</translation>
+  <translation key="icon_view_tooltip">Show app icons in both list and mosaic views</translation>
+  <translation key="view_mode_tooltip">Choose between list and mosaic view</translation>
   <translation key="import_tooltip">Import actions</translation>
   <translation key="export_tooltip">Export current actions</translation>
   <translation key="select_adb_tooltip">Select the path where the ADB executable is located</translation>
@@ -103,7 +104,10 @@
 
   <!-- Filter and Status Labels -->
   <translation key="no_matches">No matches</translation>
-  <translation key="icon_view">Icon View</translation>
+  <translation key="view_mode">View</translation>
+  <translation key="list_view">List</translation>
+  <translation key="mosaic_view">Mosaic</translation>
+  <translation key="icon_view">Show icons</translation>
   <translation key="activate" maxLength="15">Activate</translation>
   <translation key="install" maxLength="15">Install</translation>
   <translation key="uninstall" maxLength="15">Uninstall</translation>
@@ -115,7 +119,7 @@
   <translation key="enabled">Enabled</translation>
   <translation key="disabled">Disabled</translation>
   <translation key="uninstalled">Uninstalled</translation>
-  <translation key="system_user">System & User</translation>
+  <translation key="system_user">System &amp; User</translation>
   <translation key="system">System</translation>
   <translation key="user">User</translation>
   <translation key="any">Any</translation>

--- a/assets/languages/es.xml
+++ b/assets/languages/es.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">Importar datos de la comunidad</translation>
   <translation key="settings_tooltip">Ajustes</translation>
   <translation key="icon_view_tooltip">Alternar vista de íconos</translation>
+  <translation key="view_mode_tooltip">Elige entre vista de lista y mosaico</translation>
   <translation key="import_tooltip">Importar acciones</translation>
   <translation key="export_tooltip">Exportar acciones actuales</translation>
   <translation key="select_adb_tooltip">Selecciona la ruta donde está el ejecutable ADB</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">acciones.</translation>
   <translation key="icon_exported_to">Ícono exportado a</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Ordenar</translation>
+  <translation key="sort_name_asc">Nombre (A→Z)</translation>
+  <translation key="sort_name_desc">Nombre (Z→A)</translation>
+  <translation key="sort_package">Paquete</translation>
+  <translation key="sort_state">Estado</translation>
+  <translation key="sort_type">Tipo</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">Sin coincidencias</translation>
+  <translation key="view_mode">Vista</translation>
+  <translation key="list_view">Lista</translation>
+  <translation key="mosaic_view">Mosaico</translation>
   <translation key="icon_view">Vista de íconos</translation>
   <translation key="activate" maxLength="15">Activar</translation>
   <translation key="install" maxLength="15">Instalar</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">No desinstalar, solo desactivar</translation>
   <translation key="export_all_apps">Exportar lista de todas las apps</translation>
   <translation key="refresh_icons">Actualizar todos los íconos</translation>
+  <translation key="always_show_icons">Mostrar siempre los íconos</translation>
+  <translation key="always_show_icons_tooltip">Mostrar los íconos de las apps por defecto en las vistas de lista y mosaico</translation>
   <translation key="language">Idioma</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/fr.xml
+++ b/assets/languages/fr.xml
@@ -102,6 +102,14 @@
   <translation key="actions_suffix">actions.</translation>
   <translation key="icon_exported_to">Icône exportée vers</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Tri</translation>
+  <translation key="sort_name_asc">Nom (A→Z)</translation>
+  <translation key="sort_name_desc">Nom (Z→A)</translation>
+  <translation key="sort_package">Paquet</translation>
+  <translation key="sort_state">État</translation>
+  <translation key="sort_type">Type</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">Aucun résultat</translation>
   <translation key="view_mode">Affichage</translation>
@@ -159,6 +167,8 @@
   <translation key="never_uninstall">Ne jamais désinstaller, seulement désactiver</translation>
   <translation key="export_all_apps">Exporter la liste de toutes les apps</translation>
   <translation key="refresh_icons">Actualiser toutes les icônes</translation>
+  <translation key="always_show_icons">Toujours afficher les icônes</translation>
+  <translation key="always_show_icons_tooltip">Afficher les icônes des applications par défaut en vue liste et mosaïque</translation>
   <translation key="language">Langue</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/fr.xml
+++ b/assets/languages/fr.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<translations>
+  <!-- Setup -->
+  <translation key="welcome">Bienvenue !</translation>
+  <translation key="welcome_message">Supprimez facilement les applications indésirables et partagez vos listes personnalisées</translation>
+  <translation key="search_languages_hint">Trouvez votre langue...</translation>
+  <translation key="no_languages_found">Aucun résultat</translation>
+  <translation key="error_loading_languages">Impossible de charger les langues</translation>
+  <translation key="continue_button">Continuer</translation>
+
+  <!-- UI Button Labels -->
+  <translation key="check_all">Tout cocher</translation>
+  <translation key="uncheck_all">Tout décocher</translation>
+  <translation key="restore_all">Tout restaurer</translation>
+  <translation key="apply_button" maxLength="10">APPLIQUER</translation>
+  <translation key="skip">PASSER</translation>
+  <translation key="support">Soutenir</translation>
+  <translation key="reload" maxLength="10">Recharger</translation>
+  <translation key="device" maxLength="10">Appareil</translation>
+  <translation key="log" maxLength="10">Journal</translation>
+  <translation key="browse" maxLength="10">Parcourir</translation>
+  <translation key="settings" maxLength="10">Réglages</translation>
+  <translation key="import" maxLength="10">Importer</translation>
+  <translation key="export" maxLength="10">Exporter</translation>
+  <translation key="connect">Connecter</translation>
+  <translation key="disconnect">Déconnecter</translation>
+  <translation key="select_adb">Sélectionner ADB</translation>
+  <translation key="close">Fermer</translation>
+  <translation key="ok">OK</translation>
+  <translation key="select">Sélectionner</translation>
+  <translation key="cancel">Annuler</translation>
+  <translation key="copy">Copier</translation>
+  <translation key="select_adb_folder">Sélectionner le dossier ADB</translation>
+
+  <!-- Tooltips and Hints -->
+  <translation key="apply_button_tip" maxLength="80">Appliquer les modifications à l'appareil</translation>
+  <translation key="checkbox_tip" maxLength="80">Décochez pour désinstaller, recochez pour réactiver ou réinstaller</translation>
+  <translation key="support_tooltip">Soutenez le développeur ☕</translation>
+  <translation key="view_source">Voir le code source</translation>
+  <translation key="reload_tooltip">Recharger la liste des applications</translation>
+  <translation key="device_tooltip">Sélectionner un appareil</translation>
+  <translation key="log_tooltip">Voir le dernier journal</translation>
+  <translation key="browse_tooltip">Importer des données de la communauté</translation>
+  <translation key="settings_tooltip">Réglages</translation>
+  <translation key="icon_view_tooltip">Afficher les icônes des applications en vue liste et mosaïque</translation>
+  <translation key="view_mode_tooltip">Choisissez entre la vue liste et la vue mosaïque</translation>
+  <translation key="import_tooltip">Importer des actions</translation>
+  <translation key="export_tooltip">Exporter les actions actuelles</translation>
+  <translation key="select_adb_tooltip">Sélectionnez le chemin de l'exécutable ADB</translation>
+  <translation key="never_uninstall_tooltip">Seulement désactiver les applications et effacer leurs données</translation>
+  <translation key="export_all_apps_tooltip">Exporter toutes les applications, même sans modifications</translation>
+  <translation key="refresh_icons_tooltip">Toujours vider le cache des icônes pour les actualiser</translation>
+  <translation key="open_in_browser">Ouvrir dans le navigateur</translation>
+  <translation key="search_repos_hint">Rechercher des dépôts...</translation>
+  <translation key="search_repos_tooltip">Rechercher des dépôts</translation>
+  <translation key="reload_repos_tooltip">Recharger les dépôts</translation>
+  <translation key="open_github_tooltip">Ouvrir GitHub</translation>
+  <translation key="import_repo_apps_tooltip">Importer les applications du dépôt</translation>
+
+  <!-- Error and Warning Messages -->
+  <translation key="copied_to_clipboard">Copié dans le presse-papiers !</translation>
+  <translation key="connect_error_empty">Veuillez saisir l'IP et le port.</translation>
+  <translation key="connect_error_network">Impossible de se connecter à</translation>
+  <translation key="connect_error_network_check">Assurez-vous que l'appareil est sur le même réseau</translation>
+  <translation key="disconnect_error">Impossible de se déconnecter. Consultez le journal.</translation>
+  <translation key="device_offline_message">L'appareil est hors ligne.&#10;&#10;Allumez l'écran de l'appareil et déverrouillez-le.</translation>
+  <translation key="failed_open_url">Impossible d'ouvrir l'URL dans le navigateur.</translation>
+  <translation key="adb_not_installed">ADB n'est pas installé</translation>
+  <translation key="adb_path_instruction">Si ADB est déjà installé, assurez-vous qu'il est ajouté au PATH de votre système ou sélectionnez le dossier contenant l'exécutable ADB.</translation>
+  <translation key="adb_install_instruction">Pas installé ? Obtenez-le ainsi :</translation>
+  <translation key="log_copied">Journal copié !</translation>
+  <translation key="execution_log">Journal d'exécution</translation>
+  <translation key="error_fetching_repos">Erreur lors de la récupération des dépôts :</translation>
+  <translation key="error_searching_repos">Erreur lors de la recherche des dépôts :</translation>
+  <translation key="error_importing_repo">Erreur lors de l'importation du dépôt :</translation>
+  <translation key="no_devices_found">Aucun appareil trouvé. Veuillez connecter un appareil.</translation>
+  <translation key="device_unauthorized">Appareil non autorisé. Autorisez le débogage USB sur l'appareil.</translation>
+  <translation key="failed_transfer_app_manager">Échec du transfert d'app_manager vers l'appareil.&#10;&#10;Consultez le journal pour plus de détails.</translation>
+  <translation key="error_preparing_app_manager">Erreur lors de la préparation d'app_manager :</translation>
+  <translation key="failed_extract_icons">Échec de l'extraction des icônes.&#10;&#10;Consultez le journal pour plus de détails.</translation>
+  <translation key="failed_pull_icons">Échec de la récupération d'icons.zip.&#10;&#10;Consultez le journal pour plus de détails.</translation>
+  <translation key="failed_extract_zip_icons">Échec de l'extraction des icônes du zip.&#10;&#10;Consultez le journal pour plus de détails.</translation>
+  <translation key="failed_load_app_list">Échec du chargement de la liste des applications.&#10;&#10;Consultez le journal pour plus de détails.</translation>
+  <translation key="no_valid_adb_executable">Aucun exécutable ADB valide trouvé dans le dossier sélectionné.</translation>
+  <translation key="no_actions_to_export">Aucune action à exporter.</translation>
+  <translation key="invalid_json">JSON invalide.</translation>
+  <translation key="icon_file_not_found">Fichier d'icône introuvable.</translation>
+  <translation key="could_not_open_url">Impossible d'ouvrir l'URL.&#10;&#10;Utilisez ce lien :</translation>
+
+  <!-- Messages -->
+  <translation key="device_selected">Appareil sélectionné :</translation>
+  <translation key="finding_devices">Recherche d'appareils...</translation>
+  <translation key="no_apps_loaded">Aucune application chargée.</translation>
+  <translation key="no_changes_to_apply">Aucune modification à appliquer.</translation>
+  <translation key="commands_executed_successfully">Commandes exécutées avec succès !</translation>
+  <translation key="extracting_icons">Extraction des icônes...</translation>
+  <translation key="pulling_icons">Récupération des icônes...</translation>
+  <translation key="applying_changes">Application des modifications...</translation>
+  <translation key="adb_path_set">Chemin ADB défini sur</translation>
+  <translation key="exported_to">Exporté vers</translation>
+  <translation key="applied_actions">Appliqué</translation>
+  <translation key="actions_suffix">actions.</translation>
+  <translation key="icon_exported_to">Icône exportée vers</translation>
+
+  <!-- Filter and Status Labels -->
+  <translation key="no_matches">Aucun résultat</translation>
+  <translation key="view_mode">Affichage</translation>
+  <translation key="list_view">Liste</translation>
+  <translation key="mosaic_view">Mosaïque</translation>
+  <translation key="icon_view">Afficher les icônes</translation>
+  <translation key="activate" maxLength="15">Activer</translation>
+  <translation key="install" maxLength="15">Installer</translation>
+  <translation key="uninstall" maxLength="15">Désinstaller</translation>
+  <translation key="deactivate" maxLength="15">Désactiver</translation>
+  <translation key="total" maxLength="15">Total</translation>
+  <translation key="action" maxLength="15">Action</translation>
+  <translation key="count" maxLength="15">Nombre</translation>
+  <translation key="all_apps">Toutes les apps</translation>
+  <translation key="enabled">Activées</translation>
+  <translation key="disabled">Désactivées</translation>
+  <translation key="uninstalled">Désinstallées</translation>
+  <translation key="system_user">Système et utilisateur</translation>
+  <translation key="system">Système</translation>
+  <translation key="user">Utilisateur</translation>
+  <translation key="any">Toutes</translation>
+  <translation key="checked">Cochées</translation>
+  <translation key="unchecked">Décochées</translation>
+  <translation key="applicable">Applicable</translation>
+
+  <!-- App Information Labels -->
+  <translation key="name" maxLength="15">Nom</translation>
+  <translation key="id" maxLength="15">ID</translation>
+  <translation key="package" maxLength="15">Paquet</translation>
+  <translation key="type" maxLength="15">Type</translation>
+  <translation key="path" maxLength="15">Chemin</translation>
+  <translation key="hide">Masquer</translation>
+  <translation key="info">Infos</translation>
+  <translation key="export_icon">Exporter l'icône</translation>
+  <translation key="unknown_repo_name">Nom inconnu</translation>
+  <translation key="unknown_owner">Inconnu</translation>
+  <translation key="no_description">Aucune description</translation>
+  <translation key="device_fallback">Appareil</translation>
+
+  <!-- Input Field Hints -->
+  <translation key="search_hint">Rechercher des apps ou des paquets...</translation>
+  <translation key="state_label">État</translation>
+  <translation key="system_label">Système</translation>
+  <translation key="check_label">Coche</translation>
+  <translation key="device_ip">IP de l'appareil</translation>
+  <translation key="ip_hint">p. ex. 192.168.1.100</translation>
+  <translation key="port">Port</translation>
+  <translation key="port_hint">p. ex. 5555</translation>
+  <translation key="tcp_ip">TCP/IP</translation>
+  <translation key="swipe_down">Glissez vers le bas</translation>
+
+  <!-- Configuration Options -->
+  <translation key="options">Options</translation>
+  <translation key="actions">Actions</translation>
+  <translation key="never_uninstall">Ne jamais désinstaller, seulement désactiver</translation>
+  <translation key="export_all_apps">Exporter la liste de toutes les apps</translation>
+  <translation key="refresh_icons">Actualiser toutes les icônes</translation>
+  <translation key="language">Langue</translation>
+
+  <!-- Device Selector -->
+  <translation key="select_device">Sélectionner un appareil</translation>
+  <translation key="connection">Connexion</translation>
+  <translation key="serial">Série</translation>
+
+  <!-- File Picker Dialogs -->
+  <translation key="select_directory">Sélectionner un répertoire</translation>
+  <translation key="export_actions_json">Exporter les actions en JSON</translation>
+  <translation key="import_actions_json">Importer les actions JSON</translation>
+  <translation key="export_app_icon">Exporter l'icône de l'app</translation>
+</translations>

--- a/assets/languages/id.xml
+++ b/assets/languages/id.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">Impor data komunitas</translation>
   <translation key="settings_tooltip">Pengaturan</translation>
   <translation key="icon_view_tooltip">Alihkan tampilan ikon</translation>
+  <translation key="view_mode_tooltip">Pilih antara tampilan daftar dan mozaik</translation>
   <translation key="import_tooltip">Impor tindakan</translation>
   <translation key="export_tooltip">Ekspor tindakan saat ini</translation>
   <translation key="select_adb_tooltip">Pilih lokasi file eksekusi ADB</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">tindakan.</translation>
   <translation key="icon_exported_to">Ikon diekspor ke</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Urutkan</translation>
+  <translation key="sort_name_asc">Nama (A→Z)</translation>
+  <translation key="sort_name_desc">Nama (Z→A)</translation>
+  <translation key="sort_package">Paket</translation>
+  <translation key="sort_state">Status</translation>
+  <translation key="sort_type">Tipe</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">Tidak ada kecocokan</translation>
+  <translation key="view_mode">Tampilan</translation>
+  <translation key="list_view">Daftar</translation>
+  <translation key="mosaic_view">Mozaik</translation>
   <translation key="icon_view">Tampilan ikon</translation>
   <translation key="activate" maxLength="15">Aktifkan</translation>
   <translation key="install" maxLength="15">Pasang</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">Jangan hapus, hanya nonaktifkan</translation>
   <translation key="export_all_apps">Ekspor daftar semua aplikasi</translation>
   <translation key="refresh_icons">Perbarui semua ikon</translation>
+  <translation key="always_show_icons">Selalu tampilkan ikon</translation>
+  <translation key="always_show_icons_tooltip">Tampilkan ikon aplikasi secara default di tampilan daftar dan mozaik</translation>
   <translation key="language">Bahasa</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/id.xml
+++ b/assets/languages/id.xml
@@ -115,7 +115,7 @@
   <translation key="enabled">Diaktifkan</translation>
   <translation key="disabled">Dinonaktifkan</translation>
   <translation key="uninstalled">Dihapus</translation>
-  <translation key="system_user">Sistem & Pengguna</translation>
+  <translation key="system_user">Sistem &amp; Pengguna</translation>
   <translation key="system">Sistem</translation>
   <translation key="user">Pengguna</translation>
   <translation key="any">Apa saja</translation>

--- a/assets/languages/ja.xml
+++ b/assets/languages/ja.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">コミュニティデータをインポート</translation>
   <translation key="settings_tooltip">設定</translation>
   <translation key="icon_view_tooltip">アイコンビューを切り替え</translation>
+  <translation key="view_mode_tooltip">リスト表示とモザイク表示を切り替えます</translation>
   <translation key="import_tooltip">アクションをインポート</translation>
   <translation key="export_tooltip">現在のアクションをエクスポート</translation>
   <translation key="select_adb_tooltip">ADB実行ファイルの場所を選択</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">アクション。</translation>
   <translation key="icon_exported_to">アイコンをエクスポート：</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">並び替え</translation>
+  <translation key="sort_name_asc">名前 (A→Z)</translation>
+  <translation key="sort_name_desc">名前 (Z→A)</translation>
+  <translation key="sort_package">パッケージ</translation>
+  <translation key="sort_state">状態</translation>
+  <translation key="sort_type">種類</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">一致なし</translation>
+  <translation key="view_mode">表示</translation>
+  <translation key="list_view">リスト</translation>
+  <translation key="mosaic_view">モザイク</translation>
   <translation key="icon_view">アイコンビュー</translation>
   <translation key="activate" maxLength="15">有効化</translation>
   <translation key="install" maxLength="15">インストール</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">アンインストールせず無効化のみ</translation>
   <translation key="export_all_apps">すべてのアプリリストをエクスポート</translation>
   <translation key="refresh_icons">すべてのアイコンを更新</translation>
+  <translation key="always_show_icons">常にアイコンを表示</translation>
+  <translation key="always_show_icons_tooltip">リスト表示とモザイク表示の両方でアプリのアイコンを既定で表示します</translation>
   <translation key="language">言語</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/pt.xml
+++ b/assets/languages/pt.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">Importar dados da comunidade</translation>
   <translation key="settings_tooltip">Configurações</translation>
   <translation key="icon_view_tooltip">Alternar visualização de ícones</translation>
+  <translation key="view_mode_tooltip">Escolha entre visualização em lista e mosaico</translation>
   <translation key="import_tooltip">Importar ações</translation>
   <translation key="export_tooltip">Exportar ações atuais</translation>
   <translation key="select_adb_tooltip">Selecione o caminho onde está o executável ADB</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">ações.</translation>
   <translation key="icon_exported_to">Ícone exportado para</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Ordenar</translation>
+  <translation key="sort_name_asc">Nome (A→Z)</translation>
+  <translation key="sort_name_desc">Nome (Z→A)</translation>
+  <translation key="sort_package">Pacote</translation>
+  <translation key="sort_state">Estado</translation>
+  <translation key="sort_type">Tipo</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">Nenhuma correspondência</translation>
+  <translation key="view_mode">Exibição</translation>
+  <translation key="list_view">Lista</translation>
+  <translation key="mosaic_view">Mosaico</translation>
   <translation key="icon_view">Visualização de ícones</translation>
   <translation key="activate" maxLength="15">Ativar</translation>
   <translation key="install" maxLength="15">Instalar</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">Nunca desinstalar, apenas desativar</translation>
   <translation key="export_all_apps">Exportar lista de todos os apps</translation>
   <translation key="refresh_icons">Atualizar todos os ícones</translation>
+  <translation key="always_show_icons">Sempre mostrar ícones</translation>
+  <translation key="always_show_icons_tooltip">Mostrar os ícones dos apps por padrão nas visualizações de lista e mosaico</translation>
   <translation key="language">Idioma</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/ro.xml
+++ b/assets/languages/ro.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">Importă date comunitare</translation>
   <translation key="settings_tooltip">Setări</translation>
   <translation key="icon_view_tooltip">Comută vizualizarea cu pictograme</translation>
+  <translation key="view_mode_tooltip">Alege între vizualizarea listă și mozaic</translation>
   <translation key="import_tooltip">Importă acțiuni</translation>
   <translation key="export_tooltip">Exportă acțiunile curente</translation>
   <translation key="select_adb_tooltip">Selectează calea către executabilul ADB</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">acțiuni.</translation>
   <translation key="icon_exported_to">Pictogramă exportată în</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Sortare</translation>
+  <translation key="sort_name_asc">Nume (A→Z)</translation>
+  <translation key="sort_name_desc">Nume (Z→A)</translation>
+  <translation key="sort_package">Pachet</translation>
+  <translation key="sort_state">Stare</translation>
+  <translation key="sort_type">Tip</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">Nicio potrivire</translation>
+  <translation key="view_mode">Afișare</translation>
+  <translation key="list_view">Listă</translation>
+  <translation key="mosaic_view">Mozaic</translation>
   <translation key="icon_view">Vizualizare pictograme</translation>
   <translation key="activate" maxLength="15">Activează</translation>
   <translation key="install" maxLength="15">Instalează</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">Nu dezinstala, doar dezactivează</translation>
   <translation key="export_all_apps">Exportă lista tuturor aplicațiilor</translation>
   <translation key="refresh_icons">Actualizează toate pictogramele</translation>
+  <translation key="always_show_icons">Afișează mereu pictogramele</translation>
+  <translation key="always_show_icons_tooltip">Afișează implicit pictogramele aplicațiilor în vizualizările listă și mozaic</translation>
   <translation key="language">Limbă</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/ru.xml
+++ b/assets/languages/ru.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">Импортировать данные сообщества</translation>
   <translation key="settings_tooltip">Настройки</translation>
   <translation key="icon_view_tooltip">Переключить вид иконок</translation>
+  <translation key="view_mode_tooltip">Выберите между списком и мозаикой</translation>
   <translation key="import_tooltip">Импортировать действия</translation>
   <translation key="export_tooltip">Экспортировать текущие действия</translation>
   <translation key="select_adb_tooltip">Выберите путь к исполняемому файлу ADB</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">действий.</translation>
   <translation key="icon_exported_to">Иконка экспортирована в</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Сортировка</translation>
+  <translation key="sort_name_asc">Имя (A→Z)</translation>
+  <translation key="sort_name_desc">Имя (Z→A)</translation>
+  <translation key="sort_package">Пакет</translation>
+  <translation key="sort_state">Состояние</translation>
+  <translation key="sort_type">Тип</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">Нет совпадений</translation>
+  <translation key="view_mode">Вид</translation>
+  <translation key="list_view">Список</translation>
+  <translation key="mosaic_view">Мозаика</translation>
   <translation key="icon_view">Вид иконок</translation>
   <translation key="activate" maxLength="15">Активировать</translation>
   <translation key="install" maxLength="15">Установить</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">Только деактивация, без удаления</translation>
   <translation key="export_all_apps">Экспорт всех приложений</translation>
   <translation key="refresh_icons">Обновить все иконки</translation>
+  <translation key="always_show_icons">Всегда показывать значки</translation>
+  <translation key="always_show_icons_tooltip">Показывать значки приложений по умолчанию в режимах списка и мозаики</translation>
   <translation key="language">Язык</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/tr.xml
+++ b/assets/languages/tr.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">Topluluk verilerini içe aktar</translation>
   <translation key="settings_tooltip">Ayarlar</translation>
   <translation key="icon_view_tooltip">Simge görünümünü aç/kapat</translation>
+  <translation key="view_mode_tooltip">Liste ve mozaik görünümü arasında seçim yapın</translation>
   <translation key="import_tooltip">İşlemleri içe aktar</translation>
   <translation key="export_tooltip">Mevcut işlemleri dışa aktar</translation>
   <translation key="select_adb_tooltip">ADB çalıştırılabilir dosyasının bulunduğu yolu seçin</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">işlem.</translation>
   <translation key="icon_exported_to">Simge şuraya dışa aktarıldı:</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">Sırala</translation>
+  <translation key="sort_name_asc">Ad (A→Z)</translation>
+  <translation key="sort_name_desc">Ad (Z→A)</translation>
+  <translation key="sort_package">Paket</translation>
+  <translation key="sort_state">Durum</translation>
+  <translation key="sort_type">Tür</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">Eşleşme yok</translation>
+  <translation key="view_mode">Görünüm</translation>
+  <translation key="list_view">Liste</translation>
+  <translation key="mosaic_view">Mozaik</translation>
   <translation key="icon_view">Simge Görünümü</translation>
   <translation key="activate" maxLength="15">Etkinleştir</translation>
   <translation key="install" maxLength="15">Yükle</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">Asla kaldırma, yalnızca devre dışı bırak</translation>
   <translation key="export_all_apps">Tüm uygulama listesini dışa aktar</translation>
   <translation key="refresh_icons">Tüm simgeleri yenile</translation>
+  <translation key="always_show_icons">Simgeleri her zaman göster</translation>
+  <translation key="always_show_icons_tooltip">Uygulama simgelerini liste ve mozaik görünümlerinde varsayılan olarak göster</translation>
   <translation key="language">Dil</translation>
 
   <!-- Device Selector -->

--- a/assets/languages/zh.xml
+++ b/assets/languages/zh.xml
@@ -43,6 +43,7 @@
   <translation key="browse_tooltip">导入社区数据</translation>
   <translation key="settings_tooltip">设置</translation>
   <translation key="icon_view_tooltip">切换图标视图</translation>
+  <translation key="view_mode_tooltip">在列表视图和马赛克视图之间选择</translation>
   <translation key="import_tooltip">导入操作</translation>
   <translation key="export_tooltip">导出当前操作</translation>
   <translation key="select_adb_tooltip">选择ADB可执行文件所在路径</translation>
@@ -101,8 +102,19 @@
   <translation key="actions_suffix">操作。</translation>
   <translation key="icon_exported_to">图标已导出到</translation>
 
+  <!-- Sort Options -->
+  <translation key="sort_label">排序</translation>
+  <translation key="sort_name_asc">名称 (A→Z)</translation>
+  <translation key="sort_name_desc">名称 (Z→A)</translation>
+  <translation key="sort_package">包名</translation>
+  <translation key="sort_state">状态</translation>
+  <translation key="sort_type">类型</translation>
+
   <!-- Filter and Status Labels -->
   <translation key="no_matches">无匹配项</translation>
+  <translation key="view_mode">视图</translation>
+  <translation key="list_view">列表</translation>
+  <translation key="mosaic_view">马赛克</translation>
   <translation key="icon_view">图标视图</translation>
   <translation key="activate" maxLength="15">激活</translation>
   <translation key="install" maxLength="15">安装</translation>
@@ -155,6 +167,8 @@
   <translation key="never_uninstall">仅禁用应用，不卸载</translation>
   <translation key="export_all_apps">导出所有应用列表</translation>
   <translation key="refresh_icons">刷新所有图标</translation>
+  <translation key="always_show_icons">始终显示图标</translation>
+  <translation key="always_show_icons_tooltip">在列表视图和马赛克视图中默认显示应用图标</translation>
   <translation key="language">语言</translation>
 
   <!-- Device Selector -->

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -353,6 +353,7 @@ class _AppManagerPageState extends State<AppManagerPage> {
   String? _stateFilter = 'all';
   String? _systemFilter = 'all';
   String? _checkFilter = 'all';
+  String _sortBy = 'name';
   double _panelWidth = 300;
   bool _isPanelVisible = true;
   String _viewMode = 'list';
@@ -384,24 +385,54 @@ class _AppManagerPageState extends State<AppManagerPage> {
     {'value': 'applicable', 'text': 'applicable'},
   ];
 
-  List<Map<String, dynamic>> get _filteredData => ManagerService.apps.values.where((item) {
-        final matchesSearch = (item['name']?.toString().toLowerCase().contains(_searchController.text.toLowerCase()) ?? false) ||
-            (item['package']?.toString().toLowerCase().contains(_searchController.text.toLowerCase()) ?? false);
-        final matchesState = _stateFilter == 'all' || (item['state']?.toString() == _stateFilter);
-        final matchesSystem = _systemFilter == 'all' || (item['isSystem'] == (_systemFilter == '1'));
-        final state = item['state'] as int?;
-        final isChecked = item['isChecked'] as bool?;
-        final action = item['action'] as String?;
-        final matchesCheck = _checkFilter == 'all' ? true :
-            _checkFilter == '1' ? (item['isChecked'] == true) :
-            _checkFilter == '0' ? (item['isChecked'] == false) :
-            (state != null && isChecked != null) &&
-                (action == 'install-disable' ||
-                    (state > 0 && isChecked == false) ||
-                    (state == 0 && isChecked == true) ||
-                    (state < 0 && isChecked == true));
-        return matchesSearch && matchesState && matchesSystem && matchesCheck;
-      }).toList();
+  final List<Map<String, String>> sortItems = [
+    {'value': 'name', 'text': 'sort_name_asc'},
+    {'value': 'name_desc', 'text': 'sort_name_desc'},
+    {'value': 'package', 'text': 'sort_package'},
+    {'value': 'state', 'text': 'sort_state'},
+    {'value': 'type', 'text': 'sort_type'},
+  ];
+
+  List<Map<String, dynamic>> get _filteredData {
+    final list = ManagerService.apps.values.where((item) {
+      final matchesSearch = (item['name']?.toString().toLowerCase().contains(_searchController.text.toLowerCase()) ?? false) ||
+          (item['package']?.toString().toLowerCase().contains(_searchController.text.toLowerCase()) ?? false);
+      final matchesState = _stateFilter == 'all' || (item['state']?.toString() == _stateFilter);
+      final matchesSystem = _systemFilter == 'all' || (item['isSystem'] == (_systemFilter == '1'));
+      final state = item['state'] as int?;
+      final isChecked = item['isChecked'] as bool?;
+      final action = item['action'] as String?;
+      final matchesCheck = _checkFilter == 'all' ? true :
+          _checkFilter == '1' ? (item['isChecked'] == true) :
+          _checkFilter == '0' ? (item['isChecked'] == false) :
+          (state != null && isChecked != null) &&
+              (action == 'install-disable' ||
+                  (state > 0 && isChecked == false) ||
+                  (state == 0 && isChecked == true) ||
+                  (state < 0 && isChecked == true));
+      return matchesSearch && matchesState && matchesSystem && matchesCheck;
+    }).toList();
+
+    list.sort((a, b) {
+      switch (_sortBy) {
+        case 'name_desc':
+          return (b['name']?.toString() ?? '').toLowerCase().compareTo((a['name']?.toString() ?? '').toLowerCase());
+        case 'package':
+          return (a['package']?.toString() ?? '').toLowerCase().compareTo((b['package']?.toString() ?? '').toLowerCase());
+        case 'state':
+          return (b['state'] as int? ?? 0).compareTo(a['state'] as int? ?? 0);
+        case 'type':
+          final aVal = a['isSystem'] == true ? 1 : 0;
+          final bVal = b['isSystem'] == true ? 1 : 0;
+          if (bVal != aVal) return bVal.compareTo(aVal);
+          return (a['name']?.toString() ?? '').toLowerCase().compareTo((b['name']?.toString() ?? '').toLowerCase());
+        default:
+          return (a['name']?.toString() ?? '').toLowerCase().compareTo((b['name']?.toString() ?? '').toLowerCase());
+      }
+    });
+
+    return list;
+  }
 
   void _copyToClipboard(String value) {
     Clipboard.setData(ClipboardData(text: value));
@@ -435,11 +466,18 @@ class _AppManagerPageState extends State<AppManagerPage> {
   @override
   void initState() {
     super.initState();
+    _showIcons = ConfigUtils.alwaysShowIcons;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await _loadAppsFromDevice();   
+      await _loadAppsFromDevice();
     });
     _searchController.addListener(() => setState(() {}));
     Localization.languageNotifier.addListener(_onLanguageChanged);
+  }
+
+  Future<void> _setShowIcons(bool newValue) async {
+    _iconsReadyNotifier.value = ManagerService.iconsLoaded;
+    if (newValue && !ManagerService.iconsLoaded && !await _loadAppIcons()) return;
+    if (mounted) setState(() => _showIcons = newValue);
   }
 
   @override
@@ -629,6 +667,8 @@ class _AppManagerPageState extends State<AppManagerPage> {
                     ),
                   ),
                 ),
+                const SizedBox(width: 8),
+                _buildSortIconButton(),
               ],
             );
           },
@@ -867,6 +907,7 @@ class _AppManagerPageState extends State<AppManagerPage> {
                                                     builder: (_) => ConfigOverlay(
                                                       onConnect: _loadAppsFromDevice,
                                                       refreshUI: () => setState(() {}),
+                                                      onAlwaysShowIconsChanged: _setShowIcons,
                                                     ),
                                                   ),
                                                   delay: 500,
@@ -901,19 +942,18 @@ class _AppManagerPageState extends State<AppManagerPage> {
                                                     const SizedBox(height: 4),
                                                     Tooltip(
                                                       message: Localization.translate('icon_view_tooltip'),
-                                                      child: SwitchListTile(
-                                                        title: Text(Localization.translate('icon_view'), style: const TextStyle(fontSize: 13, color: Colors.white70), overflow: TextOverflow.ellipsis),
-                                                        value: _showIcons,
-                                                        onChanged: (newValue) async {
-                                                          _iconsReadyNotifier.value = ManagerService.iconsLoaded;
-                                                          if (newValue && !ManagerService.iconsLoaded && !await _loadAppIcons()) return;
-                                                          setState(() => _showIcons = newValue);
-                                                        },
-                                                        contentPadding: EdgeInsets.zero,
-                                                        activeTrackColor: Colors.blueAccent.withOpacity(0.5),
-                                                        inactiveTrackColor: Colors.grey[700],
-                                                        inactiveThumbColor: Colors.white70,
-                                                        visualDensity: const VisualDensity(horizontal: -2, vertical: -2),
+                                                      child: Material(
+                                                        type: MaterialType.transparency,
+                                                        child: SwitchListTile(
+                                                          title: Text(Localization.translate('icon_view'), style: const TextStyle(fontSize: 13, color: Colors.white70), overflow: TextOverflow.ellipsis),
+                                                          value: _showIcons,
+                                                          onChanged: _setShowIcons,
+                                                          contentPadding: EdgeInsets.zero,
+                                                          activeTrackColor: Colors.blueAccent.withOpacity(0.5),
+                                                          inactiveTrackColor: Colors.grey[700],
+                                                          inactiveThumbColor: Colors.white70,
+                                                          visualDensity: const VisualDensity(horizontal: -2, vertical: -2),
+                                                        ),
                                                       ),
                                                     ),
                                                   ],
@@ -1346,6 +1386,75 @@ class _AppManagerPageState extends State<AppManagerPage> {
     );
   }
 
+  Widget _buildSortIconButton() {
+    final isCustomSort = _sortBy != 'name';
+    return Tooltip(
+      message: Localization.translate('sort_label'),
+      child: GestureDetector(
+        onTap: () {
+          showModalBottomSheet(
+            context: context,
+            backgroundColor: Colors.transparent,
+            builder: (context) => Material(
+              color: Colors.grey[850]!.withOpacity(0.9),
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+              clipBehavior: Clip.antiAlias,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    height: 4,
+                    width: 40,
+                    margin: const EdgeInsets.symmetric(vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.white70,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  ...sortItems.map(
+                    (item) => ListTile(
+                      title: Text(
+                        Localization.translate(item['text']!),
+                        style: TextStyle(
+                          color: item['value'] == _sortBy ? Colors.blueAccent : Colors.white,
+                          fontWeight: item['value'] == _sortBy ? FontWeight.w600 : FontWeight.w400,
+                          fontSize: 14,
+                        ),
+                      ),
+                      trailing: item['value'] == _sortBy
+                          ? const Icon(Icons.check, color: Colors.blueAccent, size: 20)
+                          : null,
+                      onTap: () {
+                        setState(() => _sortBy = item['value']!);
+                        Navigator.pop(context);
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              ),
+            ),
+          );
+        },
+        child: Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: isCustomSort ? Colors.blueAccent.withOpacity(0.2) : Colors.white.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: isCustomSort ? Colors.blueAccent : Colors.white.withOpacity(0.2),
+            ),
+          ),
+          child: Icon(
+            Icons.sort,
+            color: isCustomSort ? Colors.blueAccent : Colors.white70,
+            size: 18,
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildIOSToggleButton({
     required String label,
     required String? value,
@@ -1359,11 +1468,10 @@ class _AppManagerPageState extends State<AppManagerPage> {
             showModalBottomSheet(
               context: context,
               backgroundColor: Colors.transparent,
-              builder: (context) => Container(
-                decoration: BoxDecoration(
-                  color: Colors.grey[850]!.withOpacity(0.9),
-                  borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-                ),
+              builder: (context) => Material(
+                color: Colors.grey[850]!.withOpacity(0.9),
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+                clipBehavior: Clip.antiAlias,
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -355,7 +355,8 @@ class _AppManagerPageState extends State<AppManagerPage> {
   String? _checkFilter = 'all';
   double _panelWidth = 300;
   bool _isPanelVisible = true;
-  bool _loadIcons = false;
+  String _viewMode = 'list';
+  bool _showIcons = false;
   final ValueNotifier<bool> _isLoadingNotifier = ValueNotifier(false);
   final ValueNotifier<bool> _iconsReadyNotifier = ValueNotifier(false);
   Timer? _debounceTimer;
@@ -531,13 +532,13 @@ class _AppManagerPageState extends State<AppManagerPage> {
                             valueListenable: _isLoadingNotifier,
                             builder: (context, isLoading, child) => LoadingIndicator(
                               isLoadingApps: isLoading,
-                              loadIcons: _loadIcons,
+                              loadIcons: _showIcons,
                               iconsReady: _iconsReadyNotifier.value,
                               isFilteredDataEmpty: _filteredData.isEmpty,
                             ),
                           ),
                           Expanded(
-                            child: (_loadIcons && _iconsReadyNotifier.value)
+                            child: _viewMode == 'mosaic'
                                 ? _buildIconGrid(constraints.maxWidth)
                                 : _buildAppList(),
                           ),
@@ -833,7 +834,7 @@ class _AppManagerPageState extends State<AppManagerPage> {
                                                   onPressed: () async {
                                                     if (await AdbService.selectDevice(context, showSelector: true, loadAppsCallback: _loadAppsFromDevice)) {
                                                       setState(() {
-                                                        _loadIcons = false;
+                                                        _showIcons = false;
                                                         _iconsReadyNotifier.value = false;
                                                       });
                                                     }
@@ -874,7 +875,7 @@ class _AppManagerPageState extends State<AppManagerPage> {
                                             ),
                                             const SizedBox(height: 8),
                                             Container(
-                                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
                                               decoration: BoxDecoration(
                                                 color: Colors.transparent,
                                                 borderRadius: BorderRadius.circular(8),
@@ -882,22 +883,40 @@ class _AppManagerPageState extends State<AppManagerPage> {
                                               ),
                                               child: FadeIn(
                                                 duration: const Duration(milliseconds: 550),
-                                                child: Tooltip(
-                                                  message: Localization.translate('icon_view_tooltip'),
-                                                  child: SwitchListTile(
-                                                    title: Text(Localization.translate('icon_view'), style: const TextStyle(fontSize: 13, color: Colors.white70), overflow: TextOverflow.ellipsis),
-                                                    value: _loadIcons,
-                                                    onChanged: (newValue) async {
-                                                      _iconsReadyNotifier.value = ManagerService.iconsLoaded;
-                                                      if (newValue && !ManagerService.iconsLoaded && !await _loadAppIcons()) return;
-                                                      setState(() => _loadIcons = newValue);
-                                                    },
-                                                    contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                                                    activeTrackColor: Colors.blueAccent.withOpacity(0.5),
-                                                    inactiveTrackColor: Colors.grey[700],
-                                                    inactiveThumbColor: Colors.white70,
-                                                    visualDensity: const VisualDensity(horizontal: -2, vertical: -2),
-                                                  ),
+                                                child: Column(
+                                                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                                                  children: [
+                                                    Padding(
+                                                      padding: const EdgeInsets.only(left: 4, bottom: 6),
+                                                      child: Text(
+                                                        Localization.translate('view_mode'),
+                                                        style: const TextStyle(fontSize: 12, color: Colors.white70, fontWeight: FontWeight.w600),
+                                                        overflow: TextOverflow.ellipsis,
+                                                      ),
+                                                    ),
+                                                    Tooltip(
+                                                      message: Localization.translate('view_mode_tooltip'),
+                                                      child: _buildViewModeSelector(),
+                                                    ),
+                                                    const SizedBox(height: 4),
+                                                    Tooltip(
+                                                      message: Localization.translate('icon_view_tooltip'),
+                                                      child: SwitchListTile(
+                                                        title: Text(Localization.translate('icon_view'), style: const TextStyle(fontSize: 13, color: Colors.white70), overflow: TextOverflow.ellipsis),
+                                                        value: _showIcons,
+                                                        onChanged: (newValue) async {
+                                                          _iconsReadyNotifier.value = ManagerService.iconsLoaded;
+                                                          if (newValue && !ManagerService.iconsLoaded && !await _loadAppIcons()) return;
+                                                          setState(() => _showIcons = newValue);
+                                                        },
+                                                        contentPadding: EdgeInsets.zero,
+                                                        activeTrackColor: Colors.blueAccent.withOpacity(0.5),
+                                                        inactiveTrackColor: Colors.grey[700],
+                                                        inactiveThumbColor: Colors.white70,
+                                                        visualDensity: const VisualDensity(horizontal: -2, vertical: -2),
+                                                      ),
+                                                    ),
+                                                  ],
                                                 ),
                                               ),
                                             ),
@@ -1063,6 +1082,85 @@ class _AppManagerPageState extends State<AppManagerPage> {
         ),
       );
 
+  Widget _buildViewModeSelector() => Container(
+        padding: const EdgeInsets.all(3),
+        decoration: BoxDecoration(
+          color: Colors.grey[850],
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: Colors.white.withOpacity(0.2)),
+        ),
+        child: Row(
+          children: [
+            _viewModeOption('list', Icons.view_list_rounded, Localization.translate('list_view')),
+            const SizedBox(width: 3),
+            _viewModeOption('mosaic', Icons.grid_view_rounded, Localization.translate('mosaic_view')),
+          ],
+        ),
+      );
+
+  Widget _viewModeOption(String mode, IconData icon, String label) {
+    final selected = _viewMode == mode;
+    return Expanded(
+      child: GestureDetector(
+        onTap: () => setState(() => _viewMode = mode),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
+          decoration: BoxDecoration(
+            color: selected ? Colors.blueAccent : Colors.transparent,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 16, color: selected ? Colors.white : Colors.white60),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    color: selected ? Colors.white : Colors.white60,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _appIconWidget(Map<String, dynamic> app, double size) {
+    final iconPath = app['iconPath'] as String?;
+    Widget image;
+    if (_showIcons &&
+        ManagerService.iconsLoaded &&
+        iconPath != null &&
+        !iconPath.startsWith('assets/') &&
+        File(iconPath).existsSync()) {
+      final String path = iconPath;
+      image = _iconCache.putIfAbsent(
+        path,
+        () => Image.file(
+          File(path),
+          fit: BoxFit.cover,
+          cacheWidth: 112,
+          gaplessPlayback: true,
+        ),
+      );
+    } else {
+      image = Image.asset(defaultIconPath, fit: BoxFit.cover);
+    }
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(size * 0.28),
+      child: SizedBox(width: size, height: size, child: image),
+    );
+  }
+
   Widget _buildAppList() => ListView.builder(
         padding: const EdgeInsets.all(8),
         itemCount: _filteredData.length,
@@ -1077,16 +1175,25 @@ class _AppManagerPageState extends State<AppManagerPage> {
               child: Column(
                 children: [
                   ListTile(
-                    leading: _TippableCheckbox(
-                      app: app,
-                      onChanged: () {
-                        setState(() {
-                          ManagerService.updateActionCounters();
-                          _triggerApplyHint();
-                        });
-                      },
-                      index: index,
-                      hintKey: index == 0 ? _firstCheckboxHintKey : null,
+                    leading: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _TippableCheckbox(
+                          app: app,
+                          onChanged: () {
+                            setState(() {
+                              ManagerService.updateActionCounters();
+                              _triggerApplyHint();
+                            });
+                          },
+                          index: index,
+                          hintKey: index == 0 ? _firstCheckboxHintKey : null,
+                        ),
+                        if (_showIcons && ManagerService.iconsLoaded) ...[
+                          const SizedBox(width: 6),
+                          _appIconWidget(app, 40),
+                        ],
+                      ],
                     ),
                     title: Text(
                       app['name'],
@@ -1149,27 +1256,20 @@ class _AppManagerPageState extends State<AppManagerPage> {
   Widget _buildIconGrid(double availableWidth) {
     return GridView.builder(
       padding: const EdgeInsets.all(8),
-      gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-        maxCrossAxisExtent: 140,
-        childAspectRatio: 0.75,
-        crossAxisSpacing: 8,
-        mainAxisSpacing: 8,
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 150,
+        childAspectRatio: 0.72,
+        crossAxisSpacing: 10,
+        mainAxisSpacing: 10,
       ),
       itemCount: _filteredData.length,
       itemBuilder: (context, index) {
         final app = _filteredData[index];
-        final label = app['name'].length > 18 ? '${app['name'].substring(0, 16)}…' : app['name'];
-        final iconPath = app['iconPath'] as String;
-
-        if (!_iconCache.containsKey(iconPath)) {
-          _iconCache[iconPath] = Image.file(
-            File(iconPath),
-            width: 56,
-            height: 56,
-            fit: BoxFit.cover,
-            cacheWidth: 112,
-          );
-        }
+        final iconPath = app['iconPath'] as String?;
+        final showRealIcon = _showIcons &&
+            ManagerService.iconsLoaded &&
+            iconPath != null &&
+            !iconPath.startsWith('assets/');
 
         return FadeIn(
           duration: const Duration(milliseconds: 100),
@@ -1178,7 +1278,7 @@ class _AppManagerPageState extends State<AppManagerPage> {
             margin: EdgeInsets.zero,
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
             child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
@@ -1193,49 +1293,47 @@ class _AppManagerPageState extends State<AppManagerPage> {
                     activeColor: Colors.blue,
                     checkColor: Colors.white,
                     materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: const VisualDensity(horizontal: -2, vertical: -2),
                   ),
                   const SizedBox(height: 4),
                   MouseRegion(
-                    onEnter: (_) => setState(() => app['isHovering'] = true),
-                    onExit: (_) => setState(() => app['isHovering'] = false),
+                    onEnter: showRealIcon ? (_) => setState(() => app['isHovering'] = true) : null,
+                    onExit: showRealIcon ? (_) => setState(() => app['isHovering'] = false) : null,
                     child: Stack(
                       alignment: Alignment.center,
                       children: [
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(16),
-                          child: _iconCache[iconPath],
-                        ),
-                        AnimatedOpacity(
-                          opacity: app['isHovering'] == true ? 1 : 0,
-                          duration: const Duration(milliseconds: 180),
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(16),
-                            child: Container(
-                              width: 56,
-                              height: 56,
-                              color: const Color.fromRGBO(0, 0, 0, 0.45),
-                              child: Center(
-                                child: IconButton(
-                                  icon: const Icon(Icons.download_rounded, color: Colors.white, size: 28),
-                                  tooltip: Localization.translate('export_icon'),
-                                  onPressed: () async => await FileManager.exportAppIcon(context, app['package'], app['iconPath']),
+                        _appIconWidget(app, 56),
+                        if (showRealIcon)
+                          AnimatedOpacity(
+                            opacity: app['isHovering'] == true ? 1 : 0,
+                            duration: const Duration(milliseconds: 180),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(16),
+                              child: Container(
+                                width: 56,
+                                height: 56,
+                                color: const Color.fromRGBO(0, 0, 0, 0.45),
+                                child: Center(
+                                  child: IconButton(
+                                    icon: const Icon(Icons.download_rounded, color: Colors.white, size: 28),
+                                    tooltip: Localization.translate('export_icon'),
+                                    onPressed: () async => await FileManager.exportAppIcon(context, app['package'], app['iconPath']),
+                                  ),
                                 ),
                               ),
                             ),
                           ),
-                        ),
                       ],
                     ),
                   ),
-                  const SizedBox(height: 4),
+                  const SizedBox(height: 6),
                   Expanded(
                     child: SingleChildScrollView(
                       child: Text(
-                        label,
-                        style: const TextStyle(fontSize: 13),
+                        app['name'],
+                        style: const TextStyle(fontSize: 12.5, height: 1.25, fontWeight: FontWeight.w500),
                         textAlign: TextAlign.center,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
+                        softWrap: true,
                       ),
                     ),
                   ),
@@ -1376,7 +1474,7 @@ class _AppManagerPageState extends State<AppManagerPage> {
         _firstCheckboxHintKey.currentState?.showHint();
       });
     });
-    if (_loadIcons) await _loadAppIcons();
+    if (_showIcons) await _loadAppIcons();
     _isLoadingNotifier.value = false;
     setState(() {});
   }
@@ -1385,16 +1483,17 @@ class _AppManagerPageState extends State<AppManagerPage> {
     final success = await ManagerService.loadAppIcons(context, iconsDirPath, defaultIconPath);
     if (success) {
       for (var app in ManagerService.apps.values) {
-        final iconPath = app['iconPath'] as String;
-        if (!_iconCache.containsKey(iconPath)) {
-          _iconCache[iconPath] = Image.file(
+        final iconPath = app['iconPath'] as String?;
+        if (iconPath == null || iconPath.startsWith('assets/')) continue;
+        _iconCache.putIfAbsent(
+          iconPath,
+          () => Image.file(
             File(iconPath),
-            width: 56,
-            height: 56,
             fit: BoxFit.cover,
             cacheWidth: 112,
-          );
-        }
+            gaplessPlayback: true,
+          ),
+        );
       }
     }
     _iconsReadyNotifier.value = success;

--- a/lib/overlays/config.dart
+++ b/lib/overlays/config.dart
@@ -12,7 +12,8 @@ import 'package:app_manager/widgets/language_selector.dart';
 class ConfigOverlay extends StatefulWidget {
   final VoidCallback? onConnect;
   final VoidCallback? refreshUI;
-  const ConfigOverlay({this.onConnect, this.refreshUI, super.key});
+  final Future<void> Function(bool)? onAlwaysShowIconsChanged;
+  const ConfigOverlay({this.onConnect, this.refreshUI, this.onAlwaysShowIconsChanged, super.key});
 
   @override
   State<ConfigOverlay> createState() => ConfigOverlayState();
@@ -295,6 +296,18 @@ class ConfigOverlayState extends State<ConfigOverlay> with TickerProviderStateMi
                                 setState(() {});
                                 ConfigUtils.refreshIcons = value ?? false;
                                 ConfigUtils.save();
+                              },
+                            ),
+                            OptionItem(
+                              title: Localization.translate('always_show_icons'),
+                              tooltip: Localization.translate('always_show_icons_tooltip'),
+                              value: ConfigUtils.alwaysShowIcons,
+                              onChanged: (value) {
+                                final enabled = value ?? false;
+                                setState(() {});
+                                ConfigUtils.alwaysShowIcons = enabled;
+                                ConfigUtils.save();
+                                widget.onAlwaysShowIconsChanged?.call(enabled);
                               },
                             ),
                           ],

--- a/lib/utils/config.dart
+++ b/lib/utils/config.dart
@@ -11,6 +11,7 @@ class ConfigUtils {
   static bool neverUninstallApps = false;
   static bool exportAllApps = false;
   static bool refreshIcons = false;
+  static bool alwaysShowIcons = false;
   static String? adbPath;
   static List<String> firstSteps = [];
   static Map<String, String> availableLanguages = {};
@@ -28,6 +29,7 @@ class ConfigUtils {
       'neverUninstallApps': neverUninstallApps,
       'exportAllApps': exportAllApps,
       'refreshIcons': refreshIcons,
+      'alwaysShowIcons': alwaysShowIcons,
       'adbPath': adbPath,
       'firstSteps': firstSteps,
       'currentLanguage': currentLanguage,
@@ -46,6 +48,7 @@ class ConfigUtils {
         neverUninstallApps = config['neverUninstallApps'] ?? false;
         exportAllApps = config['exportAllApps'] ?? false;
         refreshIcons = config['refreshIcons'] ?? false;
+        alwaysShowIcons = config['alwaysShowIcons'] ?? false;
         adbPath = config['adbPath'];
         firstSteps = List<String>.from(config['firstSteps'] ?? []);
         currentLanguage = config['currentLanguage'] ?? 'en';

--- a/lib/utils/localization.dart
+++ b/lib/utils/localization.dart
@@ -44,7 +44,7 @@ class Localization {
       final document = XmlDocument.parse(xmlString);
       _currentLocale = {
         for (var element in document.findAllElements('translation'))
-          element.getAttribute('key')!: element.text
+          element.getAttribute('key')!: element.innerText
       };
       ConfigUtils.currentLanguage = languageCode;
       await ConfigUtils.save();
@@ -64,7 +64,7 @@ class Localization {
       final document = XmlDocument.parse(xmlString);
       return {
         for (var element in document.findAllElements('translation'))
-          element.getAttribute('key')!: element.text
+          element.getAttribute('key')!: element.innerText
       };
     } catch (e) {
       throw Exception('Critical error: Could not load default English locale: $e');

--- a/lib/utils/localization.dart
+++ b/lib/utils/localization.dart
@@ -12,6 +12,7 @@ class Localization {
   Localization._internal();
 
   static Map<String, String>? _currentLocale;
+  static Map<String, String>? _fallbackLocale;
 
   static Future<void> loadLanguages() async {
     try {
@@ -27,7 +28,17 @@ class Localization {
     }
   }
 
+  static Future<void> _ensureFallbackLocale() async {
+    if (_fallbackLocale != null) return;
+    try {
+      _fallbackLocale = await _loadDefaultLocale();
+    } catch (_) {
+      _fallbackLocale = {};
+    }
+  }
+
   static Future<void> loadLocale(String languageCode) async {
+    await _ensureFallbackLocale();
     try {
       final String xmlString = await rootBundle.loadString('assets/languages/$languageCode.xml');
       final document = XmlDocument.parse(xmlString);
@@ -61,6 +72,6 @@ class Localization {
   }
 
   static String translate(String key) {
-    return _currentLocale?[key] ?? key;
+    return _currentLocale?[key] ?? _fallbackLocale?[key] ?? key;
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,24 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:app_manager/main.dart';
+import 'package:app_manager/utils/localization.dart';
+import 'package:app_manager/utils/config.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  group('Localization', () {
+    test('translate returns key as fallback when no locale is loaded', () {
+      expect(Localization.translate('nonexistent_key'), equals('nonexistent_key'));
+    });
+  });
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  group('ConfigUtils', () {
+    test('boolean options default to false', () {
+      expect(ConfigUtils.neverUninstallApps, isFalse);
+      expect(ConfigUtils.exportAllApps, isFalse);
+      expect(ConfigUtils.refreshIcons, isFalse);
+      expect(ConfigUtils.alwaysShowIcons, isFalse);
+    });
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    test('isFirstLaunch defaults to true', () {
+      expect(ConfigUtils.isFirstLaunch, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## ✨ Summary

This PR improves the app list UI by adding clearer display controls, sorting options, persistent icon visibility, and a new French localization.

The work is split into **3 focused commits** to make the review easier:

1. **App list display improvements**
   - Adds the List / Mosaic view selector.
   - Separates the layout mode from the Show icons option.
   - Improves app icon rendering and long app name display.

2. **French localization**
   - Adds a complete French translation file.
   - Registers French in the language selector.
   - Improves localization fallback behavior.

3. **Sorting and persistent icon preference**
   - Adds app list sorting options.
   - Adds the persistent Always show icons setting.
   - Updates related translation keys and tests.
   - Fixes the ListTile debug assertion.

## 🔧 Changes

- Added a **List / Mosaic** view selector for the app list.
- Separated the **view layout** from the **Show icons** option.
- Added an **Always show icons** setting in `Settings > Options`, persisted across launches.
- Added app list sorting by:
  - Name A-Z
  - Name Z-A
  - Package
  - State
  - Type
- Improved mosaic view behavior for long app names.
- Fixed fallback app icon rendering by using the correct asset image handling.
- Added a complete **French** translation file and registered it in the language selector.
- Added the new view/sort/icon preference translation keys to all existing locales.
- Improved localization fallback behavior so missing keys do not appear as raw UI text.
- Fixed XML escaping issues for raw `&` characters.
- Updated the widget test so `flutter test` now matches the actual app instead of the default Flutter counter template.
- Fixed the `ListTile` debug assertion caused by a decorated background around list items.

## 🧪 Testing

- [x] `flutter pub get`
- [x] `flutter test`
- [x] `flutter run -d windows`
- [ ] `flutter analyze` — runs successfully but reports existing info-level lints/deprecations

## 📸 Screenshots

<img width="1920" height="1032" alt="Capture d&#39;écran 2026-06-01 183802" src="https://github.com/user-attachments/assets/2b35a4a5-b077-47d2-bb50-30aed511506e" />
<img width="1259" height="955" alt="Capture d&#39;écran 2026-06-01 183711" src="https://github.com/user-attachments/assets/d07e10ba-5c6e-49f6-889e-350cc6076cf4" />
