### PR TITLE
🐛 Detect Android emulators in the device list

### DIFF
--- a/lib/services/adb.dart
+++ b/lib/services/adb.dart
@@ -126,6 +126,15 @@ class AdbService {
     return devices;
   }
 
+  // A valid "adb devices -l" entry is "<serial>  <state> [key:value ...]".
+  // The serial is simply the first token: a physical serial, an emulator
+  // ("emulator-5554") or an "ip:port" for WiFi. We accept the line only when the
+  // second token is a known adb state, which keeps out daemon/error noise
+  // without dropping emulators the way a serial-shape regex would.
+  static final RegExp _deviceLine = RegExp(
+      r'^(\S+)\s+(device|offline|unauthorized|bootloader|recovery|sideload|rescue|connecting|authorizing|no permissions|host|unknown)\b');
+  static final RegExp _wifiSerial = RegExp(r'^(\d{1,3}\.){3}\d{1,3}:\d+$');
+
   static List<DeviceInfo> _parseDevicesOutput(String output) {
     final lines = output.split(RegExp(r'[\r\n]+'));
     List<DeviceInfo> devices = [];
@@ -133,39 +142,33 @@ class AdbService {
     for (final line in lines) {
       if (line.contains('List of')) continue;
       if (line.trim().isEmpty) continue;
-      final wifiMatch = RegExp(r'^((\d{1,3}\.){3}\d{1,3}:\d+?)(?=[ \t])').firstMatch(line);
-      String? serial;
-      if (wifiMatch != null) {
-        serial = wifiMatch.group(1);
+      final match = _deviceLine.firstMatch(line);
+      if (match == null) continue;
+      final serial = match.group(1)!;
+      final state = match.group(2)!;
+      serialN++;
+      String name = '';
+      final modelMatch = RegExp(r'model:(\S+)').firstMatch(line);
+      if (modelMatch != null) {
+        name = modelMatch.group(1)!;
       } else {
-        final serialMatch = RegExp(r'^([a-zA-Z]*[0-9][a-zA-Z0-9]+?)(?=[ \t])').firstMatch(line);
-        if (serialMatch != null) {
-          serial = serialMatch.group(1);
-        }
-      }
-      if (serial != null) {
-        serialN++;
-        String name = '';
-        final modelMatch = RegExp(r'model:(\S+)').firstMatch(line);
-        if (modelMatch != null) {
-          name = modelMatch.group(1)!;
+        final productMatch = RegExp(r'(device product|device):(\S+)').firstMatch(line);
+        if (productMatch != null) {
+          name = productMatch.group(2)!;
         } else {
-          final productMatch = RegExp(r'(device product|device):(\S+)').firstMatch(line);
-          if (productMatch != null) {
-            name = productMatch.group(2)!;
-          } else {
-            name = '${Localization.translate('device_fallback')} $serialN';
-          }
+          name = '${Localization.translate('device_fallback')} $serialN';
         }
-        final isActive = !(line.contains('offline') || line.contains('unauthorized'));
-        final connection = RegExp(r'^((\d{1,3}\.){3}\d{1,3}:\d+?)(?=[ \t])').hasMatch(line) ? 'WIFI' : 'USB';
-        devices.add(DeviceInfo(
-          name: name,
-          serial: serial,
-          connection: connection,
-          isActive: isActive,
-        ));
       }
+      final isActive = !(state == 'offline' || state == 'unauthorized');
+      final connection = _wifiSerial.hasMatch(serial)
+          ? 'WIFI'
+          : (serial.startsWith('emulator-') ? 'EMULATOR' : 'USB');
+      devices.add(DeviceInfo(
+        name: name,
+        serial: serial,
+        connection: connection,
+        isActive: isActive,
+      ));
     }
     return devices;
   }


### PR DESCRIPTION
## ✨ Summary

This PR fixes the device picker so that **Android emulators** (e.g. Android Studio's Pixel virtual devices) show up alongside physical and WiFi devices.

Until now, emulators were silently dropped: only physical and WiFi devices ever appeared in the list. The fix is **narrow and self-contained** — it touches a single file (`lib/services/adb.dart`) and only changes how each `adb devices -l` line is parsed.

## 🔧 Changes

- The serial was extracted with a regex requiring the shape `<letters><digit><alphanumerics>` with no separator, so emulator serials like **`emulator-5554`** never matched (the hyphen breaks the pattern) and were skipped.
- The serial is now read as the **first token** of each `adb devices -l` entry, and the line is accepted only when the **second token is a known adb state** (`device`, `offline`, `unauthorized`, …). This captures **emulators, physical and WiFi devices uniformly** while still filtering out daemon/error noise.
- Emulators are now labelled with an **`EMULATOR`** connection type (next to the existing `USB` / `WIFI`).
- Active/inactive state is now derived from the parsed adb state rather than a substring search.
- **No UI, layout, or behavior changes beyond device detection.**

## 🧪 Testing

- [x] `flutter pub get`
- [x] `flutter test`
- [x] `flutter run -d windows` (verified an Android Studio emulator now appears in the picker, labelled `EMULATOR`, alongside physical/WiFi devices)
- [ ] `flutter analyze` — runs successfully; only pre-existing lints/deprecations (unrelated to this change)

## 📸 Screenshots

<img width="2444" height="1555" alt="clipboard_2026-06-18_17-34" src="https://github.com/user-attachments/assets/ed42f478-312a-497c-a906-66df8803ab09" />